### PR TITLE
Dynamic-link option update

### DIFF
--- a/makefile
+++ b/makefile
@@ -42,7 +42,7 @@ STATICLIB = $(LIBNAME).a
 LIMPLIB = $(DYNAMICLIB)
 
 LFMMLINKLIB = -lfmm3d
-LLINKLIB = -$(LIBNAME)
+LLINKLIB = $(subst lib, -l, $(LIBNAME))
 
 
 # For your OS, override the above by placing make variables in make.inc


### PR DESCRIPTION
Hello,

When I tried to run 'make test-dyn', the error message below showed up and the test failed to run while 'make test' works fine.
'/usr/bin/ld: cannot find -libfmm3dbie'
The reason I guess is that the linker interpreted '-libfmm3dbie' option as 'lib' plus 'ibfmm3dbie.so'.
Slightly changing the dynamic-link option makes test-dyn work on my side.
I would appreciate it if anyone knowledgable could take a look at it to see if this change would be useful.

The machine environment I used for the test is the following:
- CPU: Intel i5-1135G7
- OS: Ubuntu 20.04.3 LTS
- Compiler: GNU Fortran 10.30.10