### PR TITLE
adds missing varargin to surfacemesh_to_surfer function

### DIFF
--- a/matlab/@surfer/surfer.m
+++ b/matlab/@surfer/surfer.m
@@ -294,6 +294,6 @@ classdef surfer
 
     methods(Static)
         obj = load_from_file(fname,varargin);
-        [obj,varargout] = surfacemesh_to_surfer(dom);
+        [obj,varargout] = surfacemesh_to_surfer(dom,varargin);
     end
 end

--- a/matlab/test/test_array_to_surfacefun.m
+++ b/matlab/test/test_array_to_surfacefun.m
@@ -4,6 +4,7 @@ run ../startup.m
 if ~exist('surfacemesh', 'class'); return; end;
 geomtype = 'sphere';
 funtype = 'spharm';
+opts.iptype = 11;
 
 iref = 0;
 if(strcmpi(geomtype,'sphere'))
@@ -14,7 +15,7 @@ elseif(strcmpi(geomtype,'stellarator'))
     nv = 24*nref;
     domtmp = surfacemesh.stellarator(12,nu,nv);    
 end
-[S,dom] = surfer.surfacemesh_to_surfer(domtmp);
+[S,dom] = surfer.surfacemesh_to_surfer(domtmp,opts);
 
 % Choose function type
 
@@ -33,5 +34,3 @@ rhs = rhs(:);
 frhs2 = array_to_surfacefun(rhs,dom,S);
 err1 = norm(frhs-frhs2)/norm(frhs);
 fprintf('Error in interpolant = %d\n',err1);
-
-


### PR DESCRIPTION
Fixes bug that prevented passing options (`opts`) to the `surfacemesh_to_surfer` function.