### PR TITLE
adds test and fixes bug in surfer scale function

### DIFF
--- a/matlab/@surfer/scale.m
+++ b/matlab/@surfer/scale.m
@@ -3,16 +3,16 @@ function [objout,varargout] = scale(obj,sf)
 %
 % Snew = scale(S,sf) creates a new surfer object sf times bigger than S
 %  (all geometry is similarly scaled). If sf is a 3-vector, the scale
-%  factors apply in x,y,z axes respectively.
+%  factors apply in x,y,z axes respectively. If sf is a scalar, then all
+%  axes are scaled by sf.
 
   nsf = numel(sf);
-  if numel(sf) == 1
-    sf = sf*ones(3,1);
-  end
-  if (nsf ~=3) 
+  if nsf == 2 || nsf > 3
     fprintf('incompatible sizes');
     objout = surfer.empty;
     return
+  elseif nsf == 1
+    sf = sf*ones(3,1);
   end
   
   objout = affine_transf(obj,diag(sf),[0;0;0]);

--- a/matlab/test/test_scale.m
+++ b/matlab/test/test_scale.m
@@ -1,0 +1,36 @@
+% Tester for surfer scaling
+run ../startup.m
+
+% Unit sphere in origin
+R = 1;
+S = geometries.sphere(R, 6, [0;0;0]);
+
+% Error in surface area before scaling
+aerr_sphere = abs(4*pi*R^2-area(S));
+fprintf('Error in area before scaling=%d\n',aerr_sphere);
+
+% Scale to prolate spheroid using vector [a,b,c]
+a = 2.1; b = 2.1; c = 3.4;
+S_spheroid = S.scale([a,b,c]);
+
+% Validate spheroidal surface area
+ecc = sqrt(1-a^2/c^2);
+aref = 2*pi*a^2*(1+c/a/ecc*asin(ecc));
+aerr_spheroid = abs(aref-area(S_spheroid));
+fprintf('Error in area after vector scaling=%d\n',aerr_spheroid);
+
+% Scale to ellipsoid using vector [a,b,c]
+a = 0.1; b = 2.1; c = 3.4;
+S_ellipsoid = S.scale([a,b,c]);
+
+% Validate scaling factors of coordinates in each direction
+assert(max(S_ellipsoid.r(1,:))/max(S.r(1,:))==a);
+assert(max(S_ellipsoid.r(2,:))/max(S.r(2,:))==b);
+assert(max(S_ellipsoid.r(3,:))/max(S.r(3,:))==c);
+
+% Scalar scaling of sphere using scalar a
+a = 1.37;
+S_scalar_scaled = S.scale(a);
+aerr_sphere_scaled = abs(4*pi*(R*a)^2-area(S_scalar_scaled));
+fprintf('Error in area after scalar scaling=%d\n',aerr_sphere_scaled);
+


### PR DESCRIPTION
- Adds `@surfer` scaling test (that fails before fix).
- Fixes bug when scalar value is inputted to the `@surfer`  function `scale`.