### PR TITLE
Fix 5 bugs in ggq self-quadrature routines

### DIFF
--- a/src/quadratures/ggq-quads.f
+++ b/src/quadratures/ggq-quads.f
@@ -92,6 +92,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - fker: procedure pointer
 c        function handle for the kernel. Calling sequence 
 c        * fker(srcinfo,ndtarg,targinfo,ndd,dpars,ndz,zpars,ndi,ipars,val)
@@ -546,6 +547,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - fker: procedure pointer
 c        function handle for the kernel. Calling sequence 
 c        * fker(srcinfo,ndtarg,targinfo,ndd,dpars,ndz,zpars,ndi,ipars,val)
@@ -947,6 +949,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - norder: integer *8
 c        order of patch discretization
 c    - npols: integer *8
@@ -1143,6 +1146,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - norder: integer *8
 c        order of patch discretization
 c    - npols: integer *8
@@ -1406,6 +1410,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - fker: procedure pointer
 c        function handle for the kernel. Calling sequence 
 c        * fker(srcinfo,ndtarg,targinfo,ndd,dpars,ndz,zpars,ndi,ipars,val)
@@ -1871,6 +1876,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - fker: procedure pointer
 c        function handle for the kernel. Calling sequence 
 c        * fker(srcinfo,ndtarg,targinfo,ndd,dpars,ndz,zpars,ndi,ipars,val)
@@ -2273,6 +2279,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - norder: integer *8
 c        order of patch discretization
 c    - npols: integer *8
@@ -2499,6 +2506,7 @@ c    - ipv: integer *8
 c        Flag for choosing type of self-quadrature
 c        * ipv = 0, for compact/weakly singular operators
 c        * ipv = 1, for singular operators
+c        * ipv = 2, for hypersingular operators
 c    - norder: integer *8
 c        order of patch discretization
 c    - npols: integer *8

--- a/src/quadratures/ggq-selfquad-routs.f90
+++ b/src/quadratures/ggq-selfquad-routs.f90
@@ -27,7 +27,7 @@
 !       K(x,y) = 1/|x-y| smooth + p.v. 1/|x-y|^2*smooth
 !  If ipv = 2
 !       K(x,y) = 1/|x-y| smooth + p.v. 1/|x-y|^2*smooth + 
-!         f.p. 1/|x-y|^3*smooth (under construction)
+!         f.p. 1/|x-y|^3*smooth
 !
 !  Here S is a convex polygon in R^2 whose boundary is defined
 !  by an ordered set of vertices
@@ -210,7 +210,6 @@
       enddo
 
 
-      ier = 0
       return
       end subroutine
 
@@ -303,7 +302,7 @@
 !       K(x,y) = 1/|x-y| smooth + p.v. 1/|x-y|^2*smooth
 !  If ipv = 2
 !       K(x,y) = 1/|x-y| smooth + p.v. 1/|x-y|^2*smooth + 
-!         f.p. 1/|x-y|^3*smooth (under construction)
+!         f.p. 1/|x-y|^3*smooth
 !
 !  Here T is a triangle with vertices (0,0), v0, v1.
 !
@@ -565,16 +564,15 @@
 ! 
       real *8 rs(29), delta
       integer *8 i, n
+      data rs / &
+        1.0d-20, 1.0d-19, 1.0d-18, 1.0d-17, 1.0d-16, &
+        1.0d-15, 1.0d-14, 1.0d-13, 1.0d-12, 1.0d-11, &
+        1.0d-10, 1.0d-09, 1.0d-08, 1.0d-07, 1.0d-06, &
+        1.0d-05, 1.0d-04, 1.0d-03, 1.0d-02, 1.0d-01, &
+        2.0d-01, 3.0d-01, 4.0d-01, 5.0d-01, 6.0d-01, &
+        7.0d-01, 8.0d-01, 9.0d-01, 1.0d+00/
 
       delta = a/b
-
-      do i=1,20
-        rs(i) = 10**(-20+i-1)
-      enddo
-
-      do i=21,29
-        rs(i) = (i-19)*0.1d0
-      enddo
 
       n = 0
       do i = 1,28
@@ -657,14 +655,15 @@
 !        theta region number
 !
       implicit none
-      integer *8, intent(in) :: irad,ipv,ier
+      integer *8, intent(in) :: irad,ipv
       real *8, intent(in) :: r,t
-      integer *8, intent(out) :: n,ir,it
+      integer *8, intent(out) :: n,ir,it,ier
 
       real *8 rs(2,25),ts(2,25),eps
       integer *8 nn(25,25),nrs,nts
       integer *8 i
 
+      ier = 0
       eps = 1.0d-14
 
       if(irad.lt.1.or.irad.gt.9) then
@@ -677,12 +676,18 @@
         if (rs(1,ir) .le. r .AND. r .le. rs(2,ir)+eps) goto 1100
       enddo
       call prinf('r in invalid range in radfetch0*',i,0)
+      ier = 32
+      n = 0
+      return
  1100 continue
 
       do it=1,nts
         if (ts(1,it) .le. t .AND. t .le. ts(2,it)+eps) goto 1200
       enddo
       call prinf('t in invalid range in radfetch0*',i,0)
+      ier = 64
+      n = 0
+      return
  1200 continue
 
       n = nn(it,ir)


### PR DESCRIPTION
## Summary

- **Bug 1** (Critical): Remove `ier = 0` before return in `self_quadrature` that silently cleared all accumulated error codes
- **Bug 2** (Critical): Change `ier` from `intent(in)` to `intent(out)` in `get_radfetch_param`, add error returns (`ier = 32` for r out of range, `ier = 64` for theta out of range)
- **Bug 3** (Moderate): Remove "under construction" label from ipv=2, add `ipv = 2, for hypersingular operators` documentation to all 8 comment blocks in `ggq-quads.f`
- **Bug 4** (Critical): Replace integer exponentiation `10**(-20+i-1)` with `data` statement in `rquads_pv_hs` — integer `10**(-k)` evaluates to 0, making `rs(1:20)` all zero and breaking PV/HQ radial bin selection for `delta < 0.2`
- **Bug 5** (Subtle): Same `data` statement fix eliminates floating-point inexactness from `(i-19)*0.1d0` that caused off-by-one bin selection at breakpoints

## Test plan

- [x] All 91 radial quadrature transfer tests pass (selfquad3d vs fmm3dbie, exact match)
- [x] Full fmm3dbie test suite passes: 73/73 (common 8/8, helm_wrappers 2/2, lap_wrappers 2/2, surface_routs 3/3, tria_routs 27/27, quad_routs 24/24, quadratures 7/7)
- [x] No regressions introduced

🤖 Generated with [Claude Code](https://claude.ai/claude-code)