### PR TITLE
Add surfermatgmres

### DIFF
--- a/matlab/@kernel3d/kernel3d.m
+++ b/matlab/@kernel3d/kernel3d.m
@@ -20,6 +20,7 @@ classdef kernel3d
 %      'stokes'    ('stok3d', 'stok')    's', 'd', 'c'
 %      'beltrami'  ('belpde', 'bel')     'klb', 'rlb', 'khb', 'rhb'
 %      'zero'/'zeros'                    (no type needed)
+%      'one'/'ones'                      (no type needed)
 %
 %   Some kernels accept extra parameters as trailing arguments, e.g.
 %   the combined-layer Laplace kernel:
@@ -101,6 +102,12 @@ classdef kernel3d
                         else
                             obj = kernel3d.zeros();
                         end
+                    case {'o', 'one', 'ones'}
+                        if ~isempty(varargin)
+                            obj = kernel3d.ones(varargin{1});
+                        else
+                            obj = kernel3d.ones();
+                        end
                     otherwise
                         error('KERNEL3D: kernel ''%s'' not found.', kern);
                 end
@@ -141,6 +148,7 @@ classdef kernel3d
         obj    = stok3d(varargin);
         obj    = belpde(varargin);
         obj    = zeros(opdims);
+        obj    = ones(A);
         K      = interleave(kerns);
         novers = kernel3d_getnear_overs(S,t,eps,zk,sing);
         Q      = addquad(Qa,Qb,c);

--- a/matlab/@kernel3d/ones.m
+++ b/matlab/@kernel3d/ones.m
@@ -1,0 +1,83 @@
+function obj = ones(A)
+%KERNEL3D.ONES   Construct a constant kernel.
+%
+%   K = KERNEL3D.ONES() constructs a [1 1] kernel with value 1.
+%   K = KERNEL3D.ONES(A) constructs an m x n constant block kernel, A, an
+%   m x n matrix.
+%
+%   The returned kernel has:
+%     K.eval(srcinfo, targinfo)  - returns repmat(A, nt, ns)
+%     K.fmm                      - sums the density and broadcasts A*sum
+%     K.getquad                  - returns the correct quadratures for 
+%                                  near-field points
+%
+%   See also KERNEL3D, KERNEL3D.ZEROS.
+
+if nargin < 1 || isempty(A)
+    A = 1;
+end
+assert(isnumeric(A) && ismatrix(A), 'KERNEL3D.ONES: A must be a numeric 2D matrix.');
+
+m = size(A, 1);
+n = size(A, 2);
+opdims = [m n];
+
+obj           = kernel3d();
+obj.name      = 'ones';
+obj.type      = 'one';
+obj.opdims    = opdims;
+obj.zk        = 0;
+obj.ifcomplex = 0;
+obj.kernel_order = -1;
+obj.iszero    = false;
+obj.src_fields  = {};
+obj.targ_fields = {};
+
+obj.eval = @(s,t) repmat(A, size(t.r,2), size(s.r,2));
+
+obj.fmm = @fmm_;
+    function varargout = fmm_(eps, s, t, sigma) %#ok<INUSL>
+        if isstruct(t), nt = size(t.r,2); else, nt = size(t,2); end
+        blk = A * sum(reshape(sigma, n, []), 2);
+        pot = repmat(blk, nt, 1);
+        if nargout > 0, varargout{1} = pot; end
+        if nargout > 1
+            error('KERNEL3D:ones:fmm', 'Too many output arguments.');
+        end
+    end
+
+obj.getquad = @(S, eps, varargin) build_near_quad(A, m, n, S, varargin);
+
+obj.get_overs_orders = @(S,t,eps) S.norders(:);
+
+end
+
+function spmat = build_near_quad(A, m, n, S, args)
+% Near-field quadrature over the getnear(S,targinfo) patch neighborhood.
+if ~isempty(args) && isstruct(args{1}) && isfield(args{1}, 'r')
+    targinfo = args{1};
+else
+    targinfo = S;
+end
+
+rsc = getnear(S, targinfo);
+row_ptr = rsc.row_ptr;
+col_ind = rsc.col_ind;
+
+ixyzs = S.ixyzs(:);
+npols = ixyzs(2:end) - ixyzs(1:end-1);
+nquad = sum(npols(col_ind));
+
+wts = S.wts(:);
+wnear = zeros(1, nquad);
+istart = 1;
+for p = 1:numel(col_ind)
+    src_inds = ixyzs(col_ind(p)):(ixyzs(col_ind(p)+1)-1);
+    nelem = numel(src_inds);
+    wnear(istart:istart+nelem-1) = wts(src_inds);
+    istart = istart + nelem;
+end
+
+ri = kernel3d.rsc_interleave_full(m, n);
+spmat = conv_rsc_to_spmat(S, row_ptr, col_ind, kron(A(:), wnear), ri);
+end

--- a/matlab/@kernel3d/times.m
+++ b/matlab/@kernel3d/times.m
@@ -5,11 +5,13 @@ function out = times(f, g)
 %   Scales eval, fmm, getquad by c.
 %
 % Left (target) multiply:   f .* K
-%   f(t) returns (p x m x nt) or (1 x 1 x nt) for pointwise scaling.
+%   f(t) returns (p x m x nt), or a 2D array of shape
+%   (nt x p*m) or (p*m x nt)
 %   Output opdims = [p, K.opdims(2)].
 %
 % Right (source) multiply:  K .* f
-%   f(s) returns (q x p x ns) or (1 x 1 x ns), q = K.opdims(2).
+%   f(s) returns (K.opdims(2) x p x ns), or a 2D array of shape
+%   (ns x K.opdims(2)*p) or (K.opdims(2)*p x ns).
 %   Output opdims = [K.opdims(1), p].
 %
 % Constant matrix:  A .* K  or  K .* A  where A is numeric (not scalar)
@@ -19,7 +21,7 @@ function out = times(f, g)
 %
 % Note: src_fields/targ_fields are inherited from K. If f requires
 % additional geometry fields (e.g. 'n'), add them to out.src_fields or
-% out.targ_fields after calling times.
+% out.targ_fields.
 
 if isa(f, 'kernel3d') && isa(g, 'kernel3d')
     error('KERNEL3D:times:invalid', ...
@@ -95,10 +97,22 @@ if ~exist('p', 'var')
         probe.r  = randn(3,1); probe.n  = randn(3,1);
         probe.du = randn(3,1); probe.dv = randn(3,1);
         hval = h(probe);
+        rc = size(hval,1)*size(hval,2)*size(hval,3);
         if strcmp(side, 'left')
-            p = size(hval, 1);
+            mq = m;
         else
-            p = size(hval, 2);
+            mq = q;
+        end
+        if ndims(hval) == 3 || rc == 1
+            % genuine 3D tensor, or an unambiguous scalar
+            if strcmp(side, 'left')
+                p = size(hval, 1);
+            else
+                p = size(hval, 2);
+            end
+        else
+            % 2D output
+            p = rc / mq;
         end
     catch
         error('KERNEL3D:times:probe', ...
@@ -138,12 +152,36 @@ end
         end
     end
 
+    function fval3 = to3d(fval, rows, cols, npts)
+        % Handle h's that output a (rows x cols x npts) tensor,
+        % or as npts x (rows*cols) or (rows*cols) x npts matrices
+        if ndims(fval) == 3 && size(fval,3) == npts
+            fval3 = fval;
+            return
+        end
+        assert(ismatrix(fval), ...
+            'KERNEL3D:times: h output must be 2D or 3D.');
+        rc = rows*cols;
+        if isequal(size(fval), [npts, rc])
+            fval3 = permute(reshape(fval, npts, rows, cols), [2 3 1]);
+        elseif isequal(size(fval), [rc, npts])
+            fval3 = reshape(fval, rows, cols, npts);
+        elseif npts == 1 && numel(fval) == rc
+            fval3 = reshape(fval, rows, cols, 1);
+        else
+            error('KERNEL3D:times:shape', ...
+                ['h output has shape %s, expected (%d x %d x %d), ', ...
+                 '(%d x %d), or (%d x %d)'], ...
+                mat2str(size(fval)), rows, cols, npts, npts, rc, rc, npts);
+        end
+    end
+
 % Left-multiply  (h(t) post-multiplies the output)
 
     function vals = eval_left(s, t)
         nt   = size(t.r, 2);
         ns   = size(s.r, 2);
-        fval = h(t);                               % (p x m x nt)
+        fval = to3d(h(t), p, m, nt);                % (p x m x nt)
         Kmat = Keval(s, t);                        % (m*nt x q*ns)
         K3   = permute(reshape(Kmat, m, nt, q*ns), [1 3 2]);  % (m x q*ns x nt)
         out3 = apply_left(fval, K3);               % (p x q*ns x nt)
@@ -152,7 +190,7 @@ end
 
     function out = fmm_left(eps, s, t, sigma)
         nt    = size(t.r, 2);
-        fval  = h(t);                              % (p x m x nt)
+        fval  = to3d(h(t), p, m, nt);               % (p x m x nt)
         inner = Kfmm(eps, s, t, sigma);            % (m*nt x 1)
         out   = reshape(apply_left(fval, reshape(inner, m, 1, nt)), p*nt, 1);
     end
@@ -165,7 +203,7 @@ end
             targ = S;
         end
         nt   = size(targ.r, 2);
-        fval = h(targ);                            % (p x m x nt)
+        fval = to3d(h(targ), p, m, nt);             % (p x m x nt)
         Q3   = permute(reshape(full(Qinner), m, nt, q*S.npts), [1 3 2]);
         Q    = sparse(reshape(permute(apply_left(fval, Q3), [1 3 2]), p*nt, q*S.npts));
     end
@@ -175,7 +213,7 @@ end
     function vals = eval_right(s, t)
         ns   = size(s.r, 2);
         nt   = size(t.r, 2);
-        fval = h(s);                               % (q x p x ns)
+        fval = to3d(h(s), q, p, ns);                % (q x p x ns)
         Kmat = Keval(s, t);                        % (m*nt x q*ns)
         K3   = reshape(Kmat, m*nt, q, ns);
         vals = reshape(apply_right(K3, fval), m*nt, p*ns);
@@ -183,7 +221,7 @@ end
 
     function out = fmm_right(eps, s, t, sigma)
         ns     = size(s.r, 2);
-        fval   = h(s);                             % (q x p x ns)
+        fval   = to3d(h(s), q, p, ns);              % (q x p x ns)
         sig_in = reshape(apply_left(fval, reshape(sigma, p, 1, ns)), q, ns);
         out    = Kfmm(eps, s, t, sig_in);
     end
@@ -191,7 +229,7 @@ end
     function Q = getquad_right(S, eps, varargin)
         Qinner = Kgetquad(S, eps, varargin{:});
         ns   = S.npts;
-        fval = h(S);                               % (q x p x ns)
+        fval = to3d(h(S), q, p, ns);                % (q x p x ns)
         if ~isempty(varargin) && isstruct(varargin{1})
             nt = size(varargin{1}.r, 2);
         else

--- a/matlab/surfermatgmres.m
+++ b/matlab/surfermatgmres.m
@@ -1,0 +1,77 @@
+function [sol, flag, relres, iter, resvec, times] = surfermatgmres(surferobj, kern, rhs, eps, tol, maxit, objover, cors, opts)
+%SURFERMATGMRES Solve the integral equation system for given kernel and
+% surfer array using unrestarted GMRES. 
+%
+% Syntax: sol = surfermatgmres(surferobj, kern, rhs)
+%         [sol,flag,relres,iter,resvec,times] = surfermatgmres(surferobj, kern, rhs, ...
+%             eps, tol, maxit, objover, cors, opts)
+%
+% Input:
+%   surferobj - array of surfer objects describing boundary
+%   kern      - kernel3d object or matrix of kernel3d objects
+%   rhs       - right-hand side, size nrows x nrhs
+%
+% Optional input:
+%   eps     - (1e-6) quadrature tolerance
+%   tol     - (eps) gmres relative residual tolerance
+%   maxit   - (min(nrows,200)) maximum number of gmres iterations
+%   objover - oversampling specification, see surfermat
+%   cors    - sparse matrix of near-field quadrature corrections, from
+%             surfermat with corrections=true.
+%   opts    - see surfermatapply for supported options
+%
+% Output:
+%   sol    - solution, nrows x nrhs
+%   flag   - nrhs x 1, gmres convergence flag for each right-hand side
+%   relres - nrhs x 1, gmres relative residual for each right-hand side
+%   iter   - nrhs x 1, gmres iteration count for each right-hand side
+%   resvec - 1 x nrhs cell array of gmres residual history vectors
+%   times  - (nrhs+1) x 1, times(1) is the precomputation time, 
+%            times(1+i) is the gmres solve time for right-hand side i
+%
+% See also SURFERMAT, SURFERMATAPPLY.
+%
+% Author: Tristan Goodwill
+
+if nargin < 4, eps = 1e-6; end
+if nargin < 5, tol = eps; end
+if nargin < 6, maxit = []; end
+if nargin < 7, objover = []; end
+if nargin < 8, cors = []; end
+if nargin < 9, opts = []; end
+
+tprecomp = tic;
+if isempty(cors)
+    coropts = opts;
+    coropts.corrections = 1;
+    [cors,objover] = surfermat(surferobj,kern,eps,coropts);
+end
+
+nrows = size(cors,1);
+sysapply = @(x) surfermatapply(surferobj, kern, x, eps, objover, cors, opts);
+
+if isempty(maxit), maxit = min(nrows,200); end
+
+nrhs = size(rhs,2);
+
+sol    = zeros(nrows, nrhs);
+flag   = zeros(nrhs, 1);
+relres = zeros(nrhs, 1);
+iter   = zeros(nrhs, 2);
+resvec = cell(1, nrhs);
+times  = zeros(nrhs+1, 1);
+times(1) = toc(tprecomp);
+
+for i = 1:nrhs
+    tsolve = tic;
+    if nargout < 2
+        sol(:,i) = gmres(sysapply, rhs(:,i), [], tol, maxit);
+    else
+        [sol(:,i), flag(i), relres(i), iter(i,:), resvec{i}] = ...
+            gmres(sysapply, rhs(:,i), [], tol, maxit);
+    end
+    times(1+i) = toc(tsolve);
+end
+
+iter = iter(:,2);
+end

--- a/matlab/test/surfermatgmresTest.m
+++ b/matlab/test/surfermatgmresTest.m
@@ -1,0 +1,53 @@
+%
+% Tests surfermatgmres by solving a mixed boundary value
+% problem on two spheres using the representation
+%
+% u = D_1[sigma] + G(t,0) * int sigma + S_2[mu]
+%
+run ../startup.m
+
+S1 = geometries.sphere(1, 2, [0;0;0], 8, 1);
+S2 = S1 + [4;0;0];
+srfrs = [S1, S2];
+
+eps = 1e-9;
+
+src0 = []; src0.r = [0;0;0];
+srcs = []; srcs.r = [[0.3; -0.1; 0.2],[4; 0.1; -0.3]];
+
+skern = kernel3d('l', 's');
+spkern = kernel3d('l', 'sp');
+
+rhs1 = skern.eval(srcs, S1);
+rhs2 = spkern.eval(srcs, S2);
+rhs = [rhs1; rhs2];
+
+area1 = sum(S1.wts(:));
+
+kerns(2,2) = kernel3d();
+kerns(1,1) = kernel3d('l', 'd') + (@(t) skern.eval(src0,t)) .* kernel3d.ones;
+kerns(1,2) = -kernel3d('l', 's');
+kerns(2,1) =  kernel3d('l', 'dp') + (@(t) spkern.eval(src0,t)) .* kernel3d.ones;
+kerns(2,2) = -kernel3d('l', 'sp');
+
+opts_corr = [];
+opts_corr.corrections = 1;
+[cors, objover] = surfermat(srfrs, kerns, eps, opts_corr);
+cors = cors + 0.5*speye(size(cors,1));
+
+[sigma, flag, relres, iters] = surfermatgmres(srfrs, kerns, rhs, eps, 1e-8, 100, objover, cors);
+
+for i = 1:size(rhs,2)
+fprintf('flag=%d, relres=%5.2e, iters=%d \n', flag(i), relres(i), iters(i));
+end
+assert(all(flag == 0), 'gmres did not converge');
+
+targ1 = []; targ1.r = [1.7; 2.1; -0.9];
+pot = surferkerneval(srfrs, kerns(1,:), sigma, targ1, eps);
+pot_ex = skern.eval(srcs, targ1);
+
+err = abs(pot - pot_ex)./abs(pot_ex);
+fprintf('Error in exterior Dirichlet solve = %d\n', err(1));
+assert(err(1) < 1e-6, 'src 1 error too large');
+fprintf('Error in exterior Dirichlet solve = %d\n', err(2));
+assert(err(2) < 1e-6, 'src 2 error too large');


### PR DESCRIPTION
Add surfermatgmres, a thin wrapper for surfermatapply and gmres to make it easier to solve

The function also supports multiple rhs's

Also update kernel3d.times to support more reasonable function handle shapes

The included test also shows a cheap way to handle null spaces in a Laplace mixed BC example.