### PR TITLE
cache vals2coefs in ggq-quads

### DIFF
--- a/makefile
+++ b/makefile
@@ -455,7 +455,7 @@ test/quad: $(QTOBJS)
 	$(FC) $(FFLAGS) test/quad_routs/test_quadrouts.f -o test/quad_routs/int2-quad $(QTOBJS) lib-static/$(STATICLIB) $(LIBS) 
 
 
-QQOBJS = test/quadratures/test_find_near.o test/quadratures/test_adap_quad_self.o
+QQOBJS = test/quadratures/test_find_near.o test/quadratures/test_adap_quad_self.o test/quadratures/test_mixed_patch_quad.o
 test/quadrature: $(QQOBJS)
 	$(FC) $(FFLAGS) test/quadratures/test_quadratures.f -o test/quadratures/int2-quad $(QQOBJS) lib-static/$(STATICLIB) $(LIBS) 
 

--- a/src/quadratures/ggq-quads.f
+++ b/src/quadratures/ggq-quads.f
@@ -153,7 +153,12 @@ c
       real *8, allocatable :: cms(:,:),rads(:)
       real *8, allocatable :: targ_near(:,:),targ_far(:,:)
       integer *8, allocatable :: iind_near(:),iind_far(:)
-      real *8, allocatable :: umatr(:,:),vmatr(:,:),uvs(:,:),wts(:)
+c     cached vals-to-coefs matrices and quadrature weights, one entry per
+c     unique (norder,iptype) pair rather than one per patch
+      real *8, allocatable :: umats(:),wtss(:)
+      integer *8, allocatable :: iuse(:),nord_uni(:),ipt_uni(:)
+      integer *8, allocatable :: npols_uni(:),iumat_ptr(:),iwts_ptr(:)
+      integer *8 nuni,lumat,lwts,iu,iw,kuni
 
 c
 c        temporary variables
@@ -301,39 +306,46 @@ c
       t1 = second()
 C$        t1 = omp_get_wtime()
 
+      allocate(iuse(npatches),nord_uni(npatches),ipt_uni(npatches))
+      allocate(npols_uni(npatches),iumat_ptr(npatches+1))
+      allocate(iwts_ptr(npatches+1))
+      call get_ptype_uni(npatches,norders,ixyzs,iptype,nuni,iuse,
+     1   nord_uni,ipt_uni,npols_uni,iumat_ptr,iwts_ptr,lumat,lwts)
+      allocate(umats(lumat),wtss(lwts))
+      call fill_disc_exps_uni(nuni,nord_uni,ipt_uni,npols_uni,
+     1   iumat_ptr,iwts_ptr,lumat,lwts,umats,wtss)
+
 C$OMP PARALLEL DO DEFAULT(SHARED) SCHEDULE(DYNAMIC)
 C$OMP$PRIVATE(ipatch,ntarg2,xyztarg2,sints_n,sints_f,svtmp_n,svtmp_f)
 C$OMP$PRIVATE(ii,ii2,i,jpatch,svtmp2,iiif,l,ntarg2m)
 C$OMP$PRIVATE(j,iii,istart,itarg2,iqstart,jpt,jtarg)
 C$OMP$PRIVATE(targ_near,targ_far,iind_near,iind_far,rr)
 C$OMP$PRIVATE(ntarg_f,ntarg_n,npols,norder)
-C$OMP$PRIVATE(uvs,umatr,vmatr,wts)
+C$OMP$PRIVATE(kuni,iu,iw)
 C$OMP$PRIVATE(epsp,rsc,tmp,ipoly,ttype)
 
       do ipatch=1,npatches
-        
+
         npols = ixyzs(ipatch+1)-ixyzs(ipatch)
         norder = norders(ipatch)
-        allocate(uvs(2,npols),umatr(npols,npols),vmatr(npols,npols))
-        allocate(wts(npols))
+        kuni = iuse(ipatch)
+        iu = iumat_ptr(kuni)
+        iw = iwts_ptr(kuni)
         if(iptype(ipatch).eq.11) ipoly = 0
         if(iptype(ipatch).eq.12) ipoly = 1
         ttype = "F"
 
-        call get_disc_exps(norder,npols,iptype(ipatch),uvs,
-     1     umatr,vmatr,wts)
-
 c
 c  estimate rescaling of epsp needed to account for the scale of the
-c    patch 
+c    patch
 c
 
         ii = ixyzs(ipatch)
         call cross_prod3d(srcvals(4,ii),srcvals(7,ii),tmp)
-        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(1)**2
+        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw)**2
         do i=2,npols
           call cross_prod3d(srcvals(4,ii+i-1),srcvals(7,ii+i-1),tmp)
-          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(i)**2
+          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw+i-1)**2
           if(rr.lt.rsc) rsc = rr
         enddo
         epsp = eps_adap*rsc**0.25d0
@@ -395,7 +407,7 @@ c
      1      rn1,n2)
         
 
-        call zrmatmatt(ntarg_n,npols,sints_n,npols,umatr,svtmp_n)
+        call zrmatmatt(ntarg_n,npols,sints_n,npols,umats(iu),svtmp_n)
 cc
 cc       fill out far part of layer potential
 c
@@ -411,7 +423,7 @@ c
      3      ndi,ipars,npts_f_quad,qnodes_quad,qwts_quad,sints_f)
         
         
-        call zrmatmatt(ntarg_f,npols,sints_f,npols,umatr,svtmp_f)
+        call zrmatmatt(ntarg_f,npols,sints_f,npols,umats(iu),svtmp_f)
 c
 c       combine svtmp_f, svtmp_n to fill out svtmp2
 c
@@ -444,7 +456,7 @@ c
           if(ipatch.eq.jpatch) then
             call zget_ggq_self_quad_pt(ipv,norder,npols,
      1      uvs_targ(1,jtarg),iptype(ipatch),
-     2      umatr,srccoefs(1,istart),ndtarg,
+     2      umats(iu),srccoefs(1,istart),ndtarg,
      2      targvals(1,jtarg),fker,ndd,dpars,ndz,zpars,ndi,
      3      ipars,wnear(iqstart+1))
           endif
@@ -459,7 +471,6 @@ c
 
         deallocate(xyztarg2,svtmp2,svtmp_f,svtmp_n,sints_f,sints_n)
         deallocate(targ_near,targ_far,iind_near,iind_far)
-        deallocate(uvs,umatr,vmatr,wts)
       enddo
 C$OMP END PARALLEL DO      
 
@@ -610,7 +621,12 @@ c
       real *8, allocatable :: cms(:,:),rads(:)
       real *8, allocatable :: targ_near(:,:),targ_far(:,:)
       integer *8, allocatable :: iind_near(:),iind_far(:)
-      real *8, allocatable :: umatr(:,:),vmatr(:,:),uvs(:,:),wts(:)
+c     cached vals-to-coefs matrices and quadrature weights, one entry per
+c     unique (norder,iptype) pair rather than one per patch
+      real *8, allocatable :: umats(:),wtss(:)
+      integer *8, allocatable :: iuse(:),nord_uni(:),ipt_uni(:)
+      integer *8, allocatable :: npols_uni(:),iumat_ptr(:),iwts_ptr(:)
+      integer *8 nuni,lumat,lwts,iu,iw,kuni
 
 c
 c        temporary variables
@@ -759,40 +775,46 @@ c
       t1 = second()
 C$        t1 = omp_get_wtime()
 
+      allocate(iuse(npatches),nord_uni(npatches),ipt_uni(npatches))
+      allocate(npols_uni(npatches),iumat_ptr(npatches+1))
+      allocate(iwts_ptr(npatches+1))
+      call get_ptype_uni(npatches,norders,ixyzs,iptype,nuni,iuse,
+     1   nord_uni,ipt_uni,npols_uni,iumat_ptr,iwts_ptr,lumat,lwts)
+      allocate(umats(lumat),wtss(lwts))
+      call fill_disc_exps_uni(nuni,nord_uni,ipt_uni,npols_uni,
+     1   iumat_ptr,iwts_ptr,lumat,lwts,umats,wtss)
+
 C$OMP PARALLEL DO DEFAULT(SHARED) SCHEDULE(DYNAMIC)
 C$OMP$PRIVATE(ipatch,ntarg2,xyztarg2,sints_n,sints_f,svtmp_n,svtmp_f)
 C$OMP$PRIVATE(ii,ii2,i,jpatch,svtmp2,iiif,l,ntarg2m)
 C$OMP$PRIVATE(j,iii,istart,itarg2,iqstart,jpt,jtarg)
 C$OMP$PRIVATE(targ_near,targ_far,iind_near,iind_far,rr)
 C$OMP$PRIVATE(ntarg_f,ntarg_n,npols,norder)
-C$OMP$PRIVATE(uvs,umatr,vmatr,wts)
+C$OMP$PRIVATE(kuni,iu,iw)
 C$OMP$PRIVATE(rsc,tmp,epsp,ipoly,ttype)
 
       do ipatch=1,npatches
-        
+
         npols = ixyzs(ipatch+1)-ixyzs(ipatch)
         norder = norders(ipatch)
-
-        allocate(uvs(2,npols),umatr(npols,npols),vmatr(npols,npols))
-        allocate(wts(npols))
+        kuni = iuse(ipatch)
+        iu = iumat_ptr(kuni)
+        iw = iwts_ptr(kuni)
         if(iptype(ipatch).eq.11) ipoly = 0
         if(iptype(ipatch).eq.12) ipoly = 1
         ttype = "F"
 
-        call get_disc_exps(norder,npols,iptype(ipatch),uvs,
-     1     umatr,vmatr,wts)
-
 c
 c  estimate rescaling of epsp needed to account for the scale of the
-c    patch 
+c    patch
 c
 
         ii = ixyzs(ipatch)
         call cross_prod3d(srcvals(4,ii),srcvals(7,ii),tmp)
-        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(1)**2
+        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw)**2
         do i=2,npols
           call cross_prod3d(srcvals(4,ii+i-1),srcvals(7,ii+i-1),tmp)
-          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(i)**2
+          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw+i-1)**2
           if(rr.lt.rsc) rsc = rr
         enddo
         epsp = eps_adap*rsc**0.25d0
@@ -851,8 +873,8 @@ c
      1      rn1,n2)
         
 
-        call dgemm_guru('t','n',npols,ntarg_n,npols,done,umatr,npols,
-     1     sints_n,npols,dzero,svtmp_n,npols)
+        call dgemm_guru('t','n',npols,ntarg_n,npols,done,
+     1     umats(iu),npols,sints_n,npols,dzero,svtmp_n,npols)
 c
 c       fill out far part of layer potential
 c
@@ -867,8 +889,8 @@ c
      2      itargptr,ntarg_f,norder,npols,fker,ndd,dpars,ndz,zpars,
      3      ndi,ipars,npts_f_quad,qnodes_quad,qwts_quad,sints_f)
         
-        call dgemm_guru('t','n',npols,ntarg_f,npols,done,umatr,npols,
-     1     sints_f,npols,dzero,svtmp_f,npols)
+        call dgemm_guru('t','n',npols,ntarg_f,npols,done,
+     1     umats(iu),npols,sints_f,npols,dzero,svtmp_f,npols)
 c
 c       combine svtmp_f, svtmp_n to fill out svtmp2
 c
@@ -899,9 +921,10 @@ c
 
           if(ipatch.eq.jpatch) then
             call dget_ggq_self_quad_pt(ipv,norder,npols,
-     1      uvs_targ(1,jtarg),iptype(ipatch),umatr,srccoefs(1,istart),
-     2      ndtarg,targvals(1,jtarg),fker,ndd,dpars,ndz,zpars,ndi,
-     3      ipars,wnear(iqstart+1))
+     1      uvs_targ(1,jtarg),iptype(ipatch),umats(iu),
+     2      srccoefs(1,istart),
+     3      ndtarg,targvals(1,jtarg),fker,ndd,dpars,ndz,zpars,ndi,
+     4      ipars,wnear(iqstart+1))
           endif
 
           if(ipatch.ne.jpatch) then
@@ -914,7 +937,6 @@ c
 
         deallocate(xyztarg2,svtmp2,svtmp_f,svtmp_n,sints_f,sints_n)
         deallocate(targ_near,targ_far,iind_near,iind_far)
-        deallocate(uvs,umatr,vmatr,wts)
       enddo
 C$OMP END PARALLEL DO      
 
@@ -1474,7 +1496,12 @@ c
       real *8, allocatable :: cms(:,:),rads(:)
       real *8, allocatable :: targ_near(:,:),targ_far(:,:)
       integer *8, allocatable :: iind_near(:),iind_far(:)
-      real *8, allocatable :: umatr(:,:),vmatr(:,:),uvs(:,:),wts(:)
+c     cached vals-to-coefs matrices and quadrature weights, one entry per
+c     unique (norder,iptype) pair rather than one per patch
+      real *8, allocatable :: umats(:),wtss(:)
+      integer *8, allocatable :: iuse(:),nord_uni(:),ipt_uni(:)
+      integer *8, allocatable :: npols_uni(:),iumat_ptr(:),iwts_ptr(:)
+      integer *8 nuni,lumat,lwts,iu,iw,kuni
 
 c
 c        temporary variables
@@ -1622,39 +1649,46 @@ c
       t1 = second()
 C$        t1 = omp_get_wtime()
 
+      allocate(iuse(npatches),nord_uni(npatches),ipt_uni(npatches))
+      allocate(npols_uni(npatches),iumat_ptr(npatches+1))
+      allocate(iwts_ptr(npatches+1))
+      call get_ptype_uni(npatches,norders,ixyzs,iptype,nuni,iuse,
+     1   nord_uni,ipt_uni,npols_uni,iumat_ptr,iwts_ptr,lumat,lwts)
+      allocate(umats(lumat),wtss(lwts))
+      call fill_disc_exps_uni(nuni,nord_uni,ipt_uni,npols_uni,
+     1   iumat_ptr,iwts_ptr,lumat,lwts,umats,wtss)
+
 C$OMP PARALLEL DO DEFAULT(SHARED) SCHEDULE(DYNAMIC)
 C$OMP$PRIVATE(ipatch,ntarg2,xyztarg2,sints_n,sints_f,svtmp_n,svtmp_f)
 C$OMP$PRIVATE(ii,ii2,i,jpatch,svtmp2,iiif,l,ntarg2m)
 C$OMP$PRIVATE(j,iii,istart,itarg2,iqstart,jpt,jtarg)
 C$OMP$PRIVATE(targ_near,targ_far,iind_near,iind_far,rr)
 C$OMP$PRIVATE(ntarg_f,ntarg_n,npols,norder)
-C$OMP$PRIVATE(uvs,umatr,vmatr,wts)
+C$OMP$PRIVATE(kuni,iu,iw)
 C$OMP$PRIVATE(epsp,rsc,tmp,ipoly,ttype)
 
       do ipatch=1,npatches
-        
+
         npols = ixyzs(ipatch+1)-ixyzs(ipatch)
         norder = norders(ipatch)
-        allocate(uvs(2,npols),umatr(npols,npols),vmatr(npols,npols))
-        allocate(wts(npols))
+        kuni = iuse(ipatch)
+        iu = iumat_ptr(kuni)
+        iw = iwts_ptr(kuni)
         if(iptype(ipatch).eq.11) ipoly = 0
         if(iptype(ipatch).eq.12) ipoly = 1
         ttype = "F"
 
-        call get_disc_exps(norder,npols,iptype(ipatch),uvs,
-     1     umatr,vmatr,wts)
-
 c
 c  estimate rescaling of epsp needed to account for the scale of the
-c    patch 
+c    patch
 c
 
         ii = ixyzs(ipatch)
         call cross_prod3d(srcvals(4,ii),srcvals(7,ii),tmp)
-        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(1)**2
+        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw)**2
         do i=2,npols
           call cross_prod3d(srcvals(4,ii+i-1),srcvals(7,ii+i-1),tmp)
-          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(i)**2
+          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw+i-1)**2
           if(rr.lt.rsc) rsc = rr
         enddo
         epsp = eps_adap*rsc**0.25d0
@@ -1716,7 +1750,7 @@ c
      1      rn1,n2)
         
 
-        call zrmatmatt(ntarg_n,npols,sints_n,npols,umatr,svtmp_n)
+        call zrmatmatt(ntarg_n,npols,sints_n,npols,umats(iu),svtmp_n)
 cc
 cc       fill out far part of layer potential
 c
@@ -1732,7 +1766,7 @@ c
      3      ndi,ipars,npts_f_quad,qnodes_quad,qwts_quad,sints_f)
         
         
-        call zrmatmatt(ntarg_f,npols,sints_f,npols,umatr,svtmp_f)
+        call zrmatmatt(ntarg_f,npols,sints_f,npols,umats(iu),svtmp_f)
 c
 c       combine svtmp_f, svtmp_n to fill out svtmp2
 c
@@ -1765,7 +1799,7 @@ c
           if(ipatch.eq.jpatch) then
             call zget_ggq_self_quad_pt_sd(ipv,norder,npols,
      1      uvs_targ(1,jtarg),iptype(ipatch),
-     2      umatr,srccoefs(1,istart),ndtarg,
+     2      umats(iu),srccoefs(1,istart),ndtarg,
      2      targvals(1,jtarg),fker,ndd,dpars,ndz,zpars,ndi,
      3      ipars,wnear(iqstart+1))
           endif
@@ -1780,7 +1814,6 @@ c
 
         deallocate(xyztarg2,svtmp2,svtmp_f,svtmp_n,sints_f,sints_n)
         deallocate(targ_near,targ_far,iind_near,iind_far)
-        deallocate(uvs,umatr,vmatr,wts)
       enddo
 C$OMP END PARALLEL DO      
 
@@ -1941,7 +1974,12 @@ c
       real *8, allocatable :: cms(:,:),rads(:)
       real *8, allocatable :: targ_near(:,:),targ_far(:,:)
       integer *8, allocatable :: iind_near(:),iind_far(:)
-      real *8, allocatable :: umatr(:,:),vmatr(:,:),uvs(:,:),wts(:)
+c     cached vals-to-coefs matrices and quadrature weights, one entry per
+c     unique (norder,iptype) pair rather than one per patch
+      real *8, allocatable :: umats(:),wtss(:)
+      integer *8, allocatable :: iuse(:),nord_uni(:),ipt_uni(:)
+      integer *8, allocatable :: npols_uni(:),iumat_ptr(:),iwts_ptr(:)
+      integer *8 nuni,lumat,lwts,iu,iw,kuni
 
 c
 c        temporary variables
@@ -2091,40 +2129,46 @@ c
       t1 = second()
 C$        t1 = omp_get_wtime()
 
+      allocate(iuse(npatches),nord_uni(npatches),ipt_uni(npatches))
+      allocate(npols_uni(npatches),iumat_ptr(npatches+1))
+      allocate(iwts_ptr(npatches+1))
+      call get_ptype_uni(npatches,norders,ixyzs,iptype,nuni,iuse,
+     1   nord_uni,ipt_uni,npols_uni,iumat_ptr,iwts_ptr,lumat,lwts)
+      allocate(umats(lumat),wtss(lwts))
+      call fill_disc_exps_uni(nuni,nord_uni,ipt_uni,npols_uni,
+     1   iumat_ptr,iwts_ptr,lumat,lwts,umats,wtss)
+
 C$OMP PARALLEL DO DEFAULT(SHARED) SCHEDULE(DYNAMIC)
 C$OMP$PRIVATE(ipatch,ntarg2,xyztarg2,sints_n,sints_f,svtmp_n,svtmp_f)
 C$OMP$PRIVATE(ii,ii2,i,jpatch,svtmp2,iiif,l,ntarg2m)
 C$OMP$PRIVATE(j,iii,istart,itarg2,iqstart,jpt,jtarg)
 C$OMP$PRIVATE(targ_near,targ_far,iind_near,iind_far,rr)
 C$OMP$PRIVATE(ntarg_f,ntarg_n,npols,norder)
-C$OMP$PRIVATE(uvs,umatr,vmatr,wts)
+C$OMP$PRIVATE(kuni,iu,iw)
 C$OMP$PRIVATE(rsc,tmp,epsp,ipoly,ttype)
 
       do ipatch=1,npatches
-        
+
         npols = ixyzs(ipatch+1)-ixyzs(ipatch)
         norder = norders(ipatch)
-
-        allocate(uvs(2,npols),umatr(npols,npols),vmatr(npols,npols))
-        allocate(wts(npols))
+        kuni = iuse(ipatch)
+        iu = iumat_ptr(kuni)
+        iw = iwts_ptr(kuni)
         if(iptype(ipatch).eq.11) ipoly = 0
         if(iptype(ipatch).eq.12) ipoly = 1
         ttype = "F"
 
-        call get_disc_exps(norder,npols,iptype(ipatch),uvs,
-     1     umatr,vmatr,wts)
-
 c
 c  estimate rescaling of epsp needed to account for the scale of the
-c    patch 
+c    patch
 c
 
         ii = ixyzs(ipatch)
         call cross_prod3d(srcvals(4,ii),srcvals(7,ii),tmp)
-        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(1)**2
+        rsc = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw)**2
         do i=2,npols
           call cross_prod3d(srcvals(4,ii+i-1),srcvals(7,ii+i-1),tmp)
-          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wts(i)**2
+          rr = (tmp(1)**2 + tmp(2)**2 + tmp(3)**2)*wtss(iw+i-1)**2
           if(rr.lt.rsc) rsc = rr
         enddo
         epsp = eps_adap*rsc**0.25d0
@@ -2183,8 +2227,8 @@ c
      1      rn1,n2)
         
 
-        call dgemm_guru('t','n',npols,ntarg_n,npols,done,umatr,npols,
-     1     sints_n,npols,dzero,svtmp_n,npols)
+        call dgemm_guru('t','n',npols,ntarg_n,npols,done,
+     1     umats(iu),npols,sints_n,npols,dzero,svtmp_n,npols)
 c
 c       fill out far part of layer potential
 c
@@ -2199,8 +2243,8 @@ c
      2      itargptr,ntarg_f,norder,npols,fker,ndd,dpars,ndz,zpars,
      3      ndi,ipars,npts_f_quad,qnodes_quad,qwts_quad,sints_f)
         
-        call dgemm_guru('t','n',npols,ntarg_f,npols,done,umatr,npols,
-     1     sints_f,npols,dzero,svtmp_f,npols)
+        call dgemm_guru('t','n',npols,ntarg_f,npols,done,
+     1     umats(iu),npols,sints_f,npols,dzero,svtmp_f,npols)
 c
 c       combine svtmp_f, svtmp_n to fill out svtmp2
 c
@@ -2231,9 +2275,10 @@ c
 
           if(ipatch.eq.jpatch) then
             call dget_ggq_self_quad_pt_sd(ipv,norder,npols,
-     1      uvs_targ(1,jtarg),iptype(ipatch),umatr,srccoefs(1,istart),
-     2      ndtarg,targvals(1,jtarg),fker,ndd,dpars,ndz,zpars,ndi,
-     3      ipars,wnear(iqstart+1))
+     1      uvs_targ(1,jtarg),iptype(ipatch),umats(iu),
+     2      srccoefs(1,istart),
+     3      ndtarg,targvals(1,jtarg),fker,ndd,dpars,ndz,zpars,ndi,
+     4      ipars,wnear(iqstart+1))
           endif
 
           if(ipatch.ne.jpatch) then
@@ -2246,7 +2291,6 @@ c
 
         deallocate(xyztarg2,svtmp2,svtmp_f,svtmp_n,sints_f,sints_n)
         deallocate(targ_near,targ_far,iind_near,iind_far)
-        deallocate(uvs,umatr,vmatr,wts)
       enddo
 C$OMP END PARALLEL DO      
 
@@ -2723,3 +2767,77 @@ c
 c
 c
 
+
+c-----------------------------------------------------------------------
+c  Build the table of unique (norder,iptype) patch types and the flat
+c  offsets used to cache one umatr/wts pair per type.
+c-----------------------------------------------------------------------
+      subroutine get_ptype_uni(npatches,norders,ixyzs,iptype,nuni,
+     1   iuse,nord_uni,ipt_uni,npols_uni,iumat_ptr,iwts_ptr,lumat,lwts)
+      implicit integer *8 (i-n)
+      integer *8, intent(in) :: npatches,norders(npatches)
+      integer *8, intent(in) :: ixyzs(npatches+1),iptype(npatches)
+      integer *8, intent(out) :: nuni,iuse(npatches)
+      integer *8, intent(out) :: nord_uni(npatches),ipt_uni(npatches)
+      integer *8, intent(out) :: npols_uni(npatches)
+      integer *8, intent(out) :: iumat_ptr(npatches+1)
+      integer *8, intent(out) :: iwts_ptr(npatches+1),lumat,lwts
+
+      nuni = 0
+      do i=1,npatches
+        iuse(i) = 0
+        do k=1,nuni
+          if(norders(i).eq.nord_uni(k).and.
+     1       iptype(i).eq.ipt_uni(k)) then
+            iuse(i) = k
+            exit
+          endif
+        enddo
+        if(iuse(i).eq.0) then
+          nuni = nuni + 1
+          nord_uni(nuni) = norders(i)
+          ipt_uni(nuni) = iptype(i)
+          npols_uni(nuni) = ixyzs(i+1)-ixyzs(i)
+          iuse(i) = nuni
+        endif
+      enddo
+
+      iumat_ptr(1) = 1
+      iwts_ptr(1) = 1
+      do k=1,nuni
+        iumat_ptr(k+1) = iumat_ptr(k) + npols_uni(k)**2
+        iwts_ptr(k+1) = iwts_ptr(k) + npols_uni(k)
+      enddo
+      lumat = iumat_ptr(nuni+1)-1
+      lwts = iwts_ptr(nuni+1)-1
+
+      return
+      end
+c
+c
+c-----------------------------------------------------------------------
+c  Fill the cached umatr/wts tables laid out by get_ptype_uni.
+c-----------------------------------------------------------------------
+      subroutine fill_disc_exps_uni(nuni,nord_uni,ipt_uni,npols_uni,
+     1   iumat_ptr,iwts_ptr,lumat,lwts,umats,wtss)
+      implicit real *8 (a-h,o-z)
+      implicit integer *8 (i-n)
+      integer *8, intent(in) :: nuni,nord_uni(nuni),ipt_uni(nuni)
+      integer *8, intent(in) :: npols_uni(nuni)
+      integer *8, intent(in) :: iumat_ptr(nuni+1),iwts_ptr(nuni+1)
+      integer *8, intent(in) :: lumat,lwts
+      real *8, intent(out) :: umats(lumat),wtss(lwts)
+      real *8, allocatable :: uvs(:,:),vmatr(:,:)
+
+      do k=1,nuni
+        npols = npols_uni(k)
+        allocate(uvs(2,npols),vmatr(npols,npols))
+        call get_disc_exps(nord_uni(k),npols,ipt_uni(k),uvs,
+     1     umats(iumat_ptr(k)),vmatr,wtss(iwts_ptr(k)))
+        deallocate(uvs,vmatr)
+      enddo
+
+      return
+      end
+c
+c

--- a/test/quadratures/test_mixed_patch_quad.f
+++ b/test/quadratures/test_mixed_patch_quad.f
@@ -1,0 +1,354 @@
+      subroutine test_mixed_patch_quad(nsuccess)
+c
+c------------------------------------------------------------------
+c  This test verifies the "unique (norder,iptype) caching"
+c  optimization in ?getnearquad_ggq_guru (see
+c  src/quadratures/ggq-quads.f, get_ptype_uni/fill_disc_exps_uni)
+c  by exercising it on a genuinely mixed-type, mixed-order mesh.
+c
+c
+c  Strategy:
+c    * Build three small sphere meshes of different (order,type):
+c        block 1: iptype = 1  (triangle, RV nodes),   order n1
+c        block 2: iptype = 11 (quad, GL nodes),        order n2
+c        block 3: iptype = 12 (quad, cheb nodes),       order n1
+c    * Concatenate the three blocks into a single srccoefs/srcvals/
+c      norders/iptype/ixyzs mesh with npatches = npatches1+2+3.
+c    * Build a near field with exactly one target per patch
+c    * Call z/dgetnearquad_ggq_guru once on the combined mesh 
+c      and compare to the result of separately calling the same 
+c      routine on each patch in isolation 
+c------------------------------------------------------------------
+      implicit real *8 (a-h,o-z)
+      implicit integer *8 (i-n)
+
+      integer *8 int8_1, int8_11, int8_12
+      real *8 c01(3), c02(3), c03(3)
+
+      integer *8, allocatable :: norders1(:), norders2(:), norders3(:)
+      integer *8, allocatable :: iptype1(:), iptype2(:), iptype3(:)
+      integer *8, allocatable :: ixyzs1(:), ixyzs2(:), ixyzs3(:)
+      real *8, allocatable :: srcvals1(:,:), srcvals2(:,:)
+      real *8, allocatable :: srcvals3(:,:)
+      real *8, allocatable :: srccoefs1(:,:), srccoefs2(:,:)
+      real *8, allocatable :: srccoefs3(:,:)
+
+      integer *8, allocatable :: norders(:), iptype(:), ixyzs(:)
+      real *8, allocatable :: srcvals(:,:), srccoefs(:,:)
+
+      integer *8, allocatable :: ipatch_id(:)
+      real *8, allocatable :: uvs_src(:,:)
+
+      integer *8, allocatable :: row_ptr(:), col_ind(:), iquad(:)
+      integer *8 row_ptr1(2), col_ind1(1), iquad1(1)
+      integer *8 ipatch_id1(1), ixyzs_loc(2), norders_loc(1)
+      integer *8 iptype_loc(1)
+      real *8, allocatable :: srccoefs_loc(:,:), srcvals_loc(:,:)
+      real *8 targvals_loc(12), uvs_targ_loc(2)
+
+      real *8, allocatable :: targvals(:,:)
+      integer *8, allocatable :: ipatch_id_t(:)
+      real *8, allocatable :: uvs_targ_t(:,:)
+
+      complex *16, allocatable :: znear_all(:), znear_solo(:)
+      real *8, allocatable :: dnear_all(:), dnear_solo(:)
+
+      complex *16 zk
+      procedure (), pointer :: fker
+      external h3d_slp, l3d_slp
+
+      call prini(6,13)
+
+      int8_1 = 1
+      int8_11 = 11
+      int8_12 = 12
+
+c     radii/centers chosen simply so the three blocks are disjoint
+c     pieces of geometry -- the near field is specified explicitly
+c     below (self targets only) and does not depend on the blocks
+c     being adjacent in space
+
+      a1 = 1.0d0
+      a2 = 1.3d0
+      a3 = 0.7d0
+
+      n1 = 4
+      n2 = 6
+
+      na = 1
+
+      c01(1) = 0.0d0
+      c01(2) = 0.0d0
+      c01(3) = 0.0d0
+
+      c02(1) = 5.0d0
+      c02(2) = 0.0d0
+      c02(3) = 0.0d0
+
+      c03(1) = -5.0d0
+      c03(2) = 0.0d0
+      c03(3) = 0.0d0
+
+c
+c   block 1: triangles, order n1
+c
+      call get_sphere_npat_mem(a1, na, c01, n1, int8_1, npatches1,
+     1   npts1)
+      allocate(norders1(npatches1), iptype1(npatches1))
+      allocate(ixyzs1(npatches1+1))
+      allocate(srcvals1(12,npts1), srccoefs1(9,npts1))
+      call get_sphere_npat(a1, na, c01, n1, int8_1, npatches1, npts1,
+     1   norders1, ixyzs1, iptype1, srccoefs1, srcvals1)
+
+c
+c   block 2: GL quads, order n2
+c
+      call get_sphere_npat_mem(a2, na, c02, n2, int8_11, npatches2,
+     1   npts2)
+      allocate(norders2(npatches2), iptype2(npatches2))
+      allocate(ixyzs2(npatches2+1))
+      allocate(srcvals2(12,npts2), srccoefs2(9,npts2))
+      call get_sphere_npat(a2, na, c02, n2, int8_11, npatches2, npts2,
+     1   norders2, ixyzs2, iptype2, srccoefs2, srcvals2)
+
+c
+c   block 3: cheb quads, order n1 (same order as block 1, different
+c   type -- exercises a third, previously-absent cache key)
+c
+      call get_sphere_npat_mem(a3, na, c03, n1, int8_12, npatches3,
+     1   npts3)
+      allocate(norders3(npatches3), iptype3(npatches3))
+      allocate(ixyzs3(npatches3+1))
+      allocate(srcvals3(12,npts3), srccoefs3(9,npts3))
+      call get_sphere_npat(a3, na, c03, n1, int8_12, npatches3, npts3,
+     1   norders3, ixyzs3, iptype3, srccoefs3, srcvals3)
+
+      print *, "npatches1 (tri, order n1)      =", npatches1
+      print *, "npatches2 (GL quad, order n2)  =", npatches2
+      print *, "npatches3 (cheb quad, order n1)=", npatches3
+
+      npatches = npatches1 + npatches2 + npatches3
+      npts = npts1 + npts2 + npts3
+
+      allocate(norders(npatches), iptype(npatches))
+      allocate(ixyzs(npatches+1))
+      allocate(srcvals(12,npts), srccoefs(9,npts))
+
+c
+c    concatenate the three blocks into one mesh
+c
+      do i=1,npatches1
+        norders(i) = norders1(i)
+        iptype(i) = iptype1(i)
+      enddo
+      do i=1,npatches2
+        norders(npatches1+i) = norders2(i)
+        iptype(npatches1+i) = iptype2(i)
+      enddo
+      do i=1,npatches3
+        norders(npatches1+npatches2+i) = norders3(i)
+        iptype(npatches1+npatches2+i) = iptype3(i)
+      enddo
+
+      do i=1,npatches1+1
+        ixyzs(i) = ixyzs1(i)
+      enddo
+      ioff = ixyzs(npatches1+1) - 1
+      do i=1,npatches2+1
+        ixyzs(npatches1+i) = ioff + ixyzs2(i)
+      enddo
+      ioff = ixyzs(npatches1+npatches2+1) - 1
+      do i=1,npatches3+1
+        ixyzs(npatches1+npatches2+i) = ioff + ixyzs3(i)
+      enddo
+
+      do i=1,npts1
+        do j=1,12
+          srcvals(j,i) = srcvals1(j,i)
+        enddo
+        do j=1,9
+          srccoefs(j,i) = srccoefs1(j,i)
+        enddo
+      enddo
+
+      do i=1,npts2
+        do j=1,12
+          srcvals(j,npts1+i) = srcvals2(j,i)
+        enddo
+        do j=1,9
+          srccoefs(j,npts1+i) = srccoefs2(j,i)
+        enddo
+      enddo
+
+      do i=1,npts3
+        do j=1,12
+          srcvals(j,npts1+npts2+i) = srcvals3(j,i)
+        enddo
+        do j=1,9
+          srccoefs(j,npts1+npts2+i) = srccoefs3(j,i)
+        enddo
+      enddo
+
+      allocate(ipatch_id(npts), uvs_src(2,npts))
+      call get_patch_id_uvs(npatches, norders, ixyzs, iptype, npts,
+     1  ipatch_id, uvs_src)
+
+c
+c    build a near field with one target per patch: the target is
+c    the patch's own first discretization node (a self-interaction,
+c    forcing use of the self-quadrature branch), so ntarg = npatches
+c    and nnz = npatches (row i only sees column i).
+c
+      ntarg = npatches
+      nnz = npatches
+
+      allocate(row_ptr(ntarg+1), col_ind(nnz), iquad(nnz+1))
+      do i=1,ntarg
+        row_ptr(i) = i
+        col_ind(i) = i
+      enddo
+      row_ptr(ntarg+1) = ntarg+1
+
+      iquad(1) = 1
+      do i=1,nnz
+        ip = col_ind(i)
+        npols = ixyzs(ip+1)-ixyzs(ip)
+        iquad(i+1) = iquad(i) + npols
+      enddo
+      nquad = iquad(nnz+1)-1
+
+      allocate(znear_all(nquad), dnear_all(nquad))
+      allocate(znear_solo(nquad), dnear_solo(nquad))
+
+      ndd = 0
+      ndz = 1
+      ndi = 0
+      ipv = 0
+      eps = 1.0d-9
+      rfac0 = 1.25d0
+      zk = 1.1d0
+
+      ndtarg = 12
+
+c
+c    targets: self node of each patch, i.e. srcvals(:,ixyzs(ip)),
+c    which is exactly what get_patch_id_uvs/ixyzs already index, so
+c    we can just reuse srcvals(1,ixyzs(ip)) as the target list --
+c    build a compact targvals array with one column per patch.
+c
+      allocate(targvals(ndtarg,ntarg))
+      allocate(ipatch_id_t(ntarg), uvs_targ_t(2,ntarg))
+      do ip=1,npatches
+        istart = ixyzs(ip)
+        do j=1,ndtarg
+          targvals(j,ip) = srcvals(j,istart)
+        enddo
+        ipatch_id_t(ip) = ipatch_id(istart)
+        uvs_targ_t(1,ip) = uvs_src(1,istart)
+        uvs_targ_t(2,ip) = uvs_src(2,istart)
+      enddo
+
+      fker => h3d_slp
+      call zgetnearquad_ggq_guru(npatches, norders, ixyzs, iptype,
+     1  npts, srccoefs, srcvals, ndtarg, ntarg, targvals,
+     2  ipatch_id_t, uvs_targ_t, eps, ipv, fker, ndd, dpars, ndz, zk,
+     3  ndi, ipars, nnz, row_ptr, col_ind, iquad, rfac0, nquad,
+     4  znear_all)
+
+      fker => l3d_slp
+      call dgetnearquad_ggq_guru(npatches, norders, ixyzs, iptype,
+     1  npts, srccoefs, srcvals, ndtarg, ntarg, targvals,
+     2  ipatch_id_t, uvs_targ_t, eps, ipv, fker, ndd, dpars, ndz, zk,
+     3  ndi, ipars, nnz, row_ptr, col_ind, iquad, rfac0, nquad,
+     4  dnear_all)
+
+c
+c    now recompute the same self-quadrature entries one patch at a
+c    time (npatches_use = 1 slices, exactly as test_adap_quad_self.f
+c    does).  Each such call only ever builds nuni = 1 cache entry,
+c    so it cannot suffer from any multi-entry indexing bug -- this
+c    is the reference to compare against.
+c
+      row_ptr1(1) = 1
+      row_ptr1(2) = 2
+      col_ind1(1) = 1
+      iquad1(1) = 1
+      ipatch_id1(1) = 1
+      ixyzs_loc(1) = 1
+
+c     each "solo" call below is built on freshly-sized local buffers
+c     holding only patch ip's own points, renumbered to start at
+c     local index 1 -- this avoids any pointer-arithmetic aliasing
+c     between the global mesh's point offsets and the small
+c     (npatches=1) array shapes the callee expects, so the only
+c     thing that can differ between this call and the combined call
+c     above is whether the vals-to-coefs cache had 1 or nuni=3
+c     entries when norder/iptype for this exact patch was looked up.
+
+      do ip=1,npatches
+        npols = ixyzs(ip+1)-ixyzs(ip)
+        istart = ixyzs(ip)
+
+        norders_loc(1) = norders(ip)
+        iptype_loc(1) = iptype(ip)
+        ixyzs_loc(2) = npols+1
+
+        allocate(srccoefs_loc(9,npols), srcvals_loc(12,npols))
+        do i=1,npols
+          do j=1,9
+            srccoefs_loc(j,i) = srccoefs(j,istart+i-1)
+          enddo
+          do j=1,12
+            srcvals_loc(j,i) = srcvals(j,istart+i-1)
+          enddo
+        enddo
+
+        do j=1,ndtarg
+          targvals_loc(j) = targvals(j,ip)
+        enddo
+        uvs_targ_loc(1) = uvs_targ_t(1,ip)
+        uvs_targ_loc(2) = uvs_targ_t(2,ip)
+
+        fker => h3d_slp
+        call zgetnearquad_ggq_guru(int8_1, norders_loc, ixyzs_loc,
+     1    iptype_loc, npols, srccoefs_loc, srcvals_loc,
+     2    ndtarg, int8_1, targvals_loc, ipatch_id1,
+     3    uvs_targ_loc, eps, ipv, fker, ndd, dpars, ndz, zk,
+     4    ndi, ipars, int8_1, row_ptr1, col_ind1, iquad1,
+     5    rfac0, npols, znear_solo(iquad(ip)))
+
+        fker => l3d_slp
+        call dgetnearquad_ggq_guru(int8_1, norders_loc, ixyzs_loc,
+     1    iptype_loc, npols, srccoefs_loc, srcvals_loc,
+     2    ndtarg, int8_1, targvals_loc, ipatch_id1,
+     3    uvs_targ_loc, eps, ipv, fker, ndd, dpars, ndz, zk,
+     4    ndi, ipars, int8_1, row_ptr1, col_ind1, iquad1,
+     5    rfac0, npols, dnear_solo(iquad(ip)))
+
+        deallocate(srccoefs_loc, srcvals_loc)
+      enddo
+
+      erra_z = 0
+      ra_z = 0
+      erra_d = 0
+      ra_d = 0
+      do i=1,nquad
+        erra_z = erra_z + abs(znear_all(i)-znear_solo(i))**2
+        ra_z = ra_z + abs(znear_solo(i))**2
+        erra_d = erra_d + (dnear_all(i)-dnear_solo(i))**2
+        ra_d = ra_d + dnear_solo(i)**2
+      enddo
+      erra_z = sqrt(erra_z/ra_z)
+      erra_d = sqrt(erra_d/ra_d)
+
+      call prin2('relative error, complex mixed-type near quad =*',
+     1   erra_z, 1)
+      call prin2('relative error, real mixed-type near quad =*',
+     1   erra_d, 1)
+
+      nsuccess = 0
+      if(erra_z.lt.1.0d-12) nsuccess = nsuccess + 1
+      if(erra_d.lt.1.0d-12) nsuccess = nsuccess + 1
+
+      return
+      end

--- a/test/quadratures/test_quadratures.f
+++ b/test/quadratures/test_quadratures.f
@@ -6,9 +6,12 @@
       ntests = ntests + 6
       call test_adap_quad_self(i2)
 
-      print *, i1, i2
+      ntests = ntests + 2
+      call test_mixed_patch_quad(i3)
 
-      nsuccess = i1 + i2
+      print *, i1, i2, i3
+
+      nsuccess = i1 + i2 + i3
 
       open(unit=33,file='../../print_testres.txt',access='append')
       write(33,'(a,i2,a,i2,a)') 'Successfully completed ',nsuccess,


### PR DESCRIPTION
Update ggq-quads.f so that it only computes vals2coefs once per unique patch type. This makes simple codes much faster.

e.g. the change makes surfermat(geometries.sphere(1, 2, [0;0;0], 8, 1), kernel3d('l', 'd'), 1e-6, struct('corrections',1)) about 8 times faster on my laptop